### PR TITLE
[Editor][Bug] Fix editors for integers

### DIFF
--- a/src/Platform/OpenGL/Shaders/Library/displacement.glsl
+++ b/src/Platform/OpenGL/Shaders/Library/displacement.glsl
@@ -18,12 +18,12 @@ vec2 applyParallaxMapping(vec2 texCoords, vec3 viewDirectionNormalSpace, sampler
     vec2 deltaTexCoords = P / numLayers;
 
     vec2  currentTexCoords = texCoords;
-    float currentDepthMapValue = texture2D(heightMap, currentTexCoords).r;
+    float currentDepthMapValue = texture(heightMap, currentTexCoords).r;
 
     while (currentLayerDepth < currentDepthMapValue && currentLayerDepth < 1.0)
     {
         currentTexCoords += deltaTexCoords;
-        currentDepthMapValue = texture2D(heightMap, currentTexCoords).r;
+        currentDepthMapValue = texture(heightMap, currentTexCoords).r;
         currentLayerDepth += layerDepth;
     }
 

--- a/src/Platform/OpenGL/Shaders/Library/ibl_lighting.glsl
+++ b/src/Platform/OpenGL/Shaders/Library/ibl_lighting.glsl
@@ -13,7 +13,7 @@ vec3 calculateIBL(FragmentInfo fragment, vec3 viewDirection, EnvironmentInfo env
     
     vec3 prefilteredColor = calcReflectionColor(environment.skybox, environment.skyboxRotation, viewDirection, fragment.normal, lod);
     prefilteredColor = pow(prefilteredColor, vec3(gamma));
-    vec2 envBRDF = texture2D(environment.envBRDFLUT, vec2(NV, 1.0 - roughness)).rg;
+    vec2 envBRDF = texture(environment.envBRDFLUT, vec2(NV, 1.0 - roughness)).rg;
     vec3 specularColor = prefilteredColor * (F * envBRDF.x + envBRDF.y);
 
     vec3 irradianceColor = calcReflectionColor(environment.irradiance, environment.skyboxRotation, viewDirection, fragment.normal);

--- a/src/Platform/OpenGL/Shaders/depthcubemap_fragment.glsl
+++ b/src/Platform/OpenGL/Shaders/depthcubemap_fragment.glsl
@@ -7,7 +7,7 @@ uniform sampler2D map_albedo;
 
 void main()
 {
-    float alpha = texture2D(map_albedo, TexCoord).a;
+    float alpha = texture(map_albedo, TexCoord).a;
     if (alpha < 0.5)
         discard;
 

--- a/src/Utilities/ImGui/Editors/ComponentEditor.cpp
+++ b/src/Utilities/ImGui/Editors/ComponentEditor.cpp
@@ -158,7 +158,7 @@ namespace MxEngine::GUI
         return Edit(name, (float)val, meta);
     }
 
-    rttr::variant Edit(const char* name, int64_t val, const ReflectionMeta & meta)
+    rttr::variant Edit(const char* name, int64_t val, const ReflectionMeta& meta)
     {
         auto editVal = (int)val;
         bool edited = ImGui::DragInt(name, &editVal, meta.Editor.EditPrecision, int(meta.Editor.EditRange.Min), int(meta.Editor.EditRange.Max));
@@ -167,17 +167,23 @@ namespace MxEngine::GUI
 
     rttr::variant Edit(const char* name, uint64_t val, const ReflectionMeta& meta)
     {
-        return Edit(name, (int64_t)val, meta);
+        auto editVal = (int)val;
+        bool edited = ImGui::DragInt(name, &editVal, meta.Editor.EditPrecision, int(meta.Editor.EditRange.Min), int(meta.Editor.EditRange.Max));
+        return edited ? rttr::variant{ (uint64_t)editVal } : rttr::variant{ };
     }
 
     rttr::variant Edit(const char* name, uint32_t val, const ReflectionMeta& meta)
     {
-        return Edit(name, (int64_t)val, meta);
+        auto editVal = (int)val;
+        bool edited = ImGui::DragInt(name, &editVal, meta.Editor.EditPrecision, int(meta.Editor.EditRange.Min), int(meta.Editor.EditRange.Max));
+        return edited ? rttr::variant{ (uint32_t)editVal } : rttr::variant{ };
     }
 
     rttr::variant Edit(const char* name, int32_t val, const ReflectionMeta& meta)
     {
-        return Edit(name, (int64_t)val, meta);
+        auto editVal = (int)val;
+        bool edited = ImGui::DragInt(name, &editVal, meta.Editor.EditPrecision, int(meta.Editor.EditRange.Min), int(meta.Editor.EditRange.Max));
+        return edited ? rttr::variant{ (int32_t)editVal } : rttr::variant{ };
     }
 
     rttr::variant Edit(const char* name, Quaternion val, const ReflectionMeta& meta)
@@ -303,10 +309,10 @@ namespace MxEngine::GUI
             VISITOR_DISPLAY_ENTRY(bool),
             VISITOR_DISPLAY_ENTRY(MxString),
             VISITOR_DISPLAY_ENTRY(float),
-            VISITOR_DISPLAY_ENTRY(double),
-            VISITOR_DISPLAY_ENTRY(int),
-            VISITOR_DISPLAY_ENTRY(unsigned int),
-            VISITOR_DISPLAY_ENTRY(size_t),
+            VISITOR_DISPLAY_ENTRY(int32_t),
+            VISITOR_DISPLAY_ENTRY(uint32_t),
+            VISITOR_DISPLAY_ENTRY(int64_t),
+            VISITOR_DISPLAY_ENTRY(uint64_t),
             VISITOR_DISPLAY_ENTRY(Quaternion),
             VISITOR_DISPLAY_ENTRY(Vector2),
             VISITOR_DISPLAY_ENTRY(Vector3),
@@ -347,9 +353,10 @@ namespace MxEngine::GUI
             VISITOR_EDIT_ENTRY(MxString),
             VISITOR_EDIT_ENTRY(float),
             VISITOR_EDIT_ENTRY(double),
-            VISITOR_EDIT_ENTRY(int),
-            VISITOR_EDIT_ENTRY(unsigned int),
-            VISITOR_EDIT_ENTRY(size_t),
+            VISITOR_EDIT_ENTRY(int32_t),
+            VISITOR_EDIT_ENTRY(uint32_t),
+            VISITOR_EDIT_ENTRY(int64_t),
+            VISITOR_EDIT_ENTRY(uint64_t),
             VISITOR_EDIT_ENTRY(Quaternion),
             VISITOR_EDIT_ENTRY(Vector2),
             VISITOR_EDIT_ENTRY(Vector3),


### PR DESCRIPTION
My recent PR (https://github.com/asc-community/MxEngine/pull/69) broke component editors for int32's as I just redirected them to int64 editors, whichs not correct, as rttr cannot assign the properties back, assuming they store values of different type. As a result, some editors were not working

Also decided to replace texture2D -> texture in this PR just for consistency